### PR TITLE
Fix minimum provider version

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     flexibleengine = {
       source  = "FlexibleEngineCloud/flexibleengine"
-      version = ">= 1.34"
+      version = ">= 1.44"
     }
   }
   required_version = ">= 0.13"


### PR DESCRIPTION
container runtime paramater needs version 1.44 of Flexible Engine provider