### PR TITLE
Add annotations - issue #23

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ module "cce2_cluster" {
     node_os      = "CentOS 7.5" // Can be "EulerOS 2.5" or "CentOS 7.5"
     node_runtime = "containerd // Valid values are docker and containerd"
     key_pair     = "my-key"
+
+    annotations  = { "cluster.install.addons.external/install": "[{\"addonTemplateName\":\"icagent\"}]" }
  
     nodes_list = [
       {

--- a/main.tf
+++ b/main.tf
@@ -8,6 +8,7 @@ resource "flexibleengine_cce_cluster_v3" "cce_cluster" {
   container_network_type = var.container_network_type
   eip                    = var.cluster_eip
   description            = var.cluster_desc
+  annotations            = var.annotations
   extend_param           = var.extend_param
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -76,6 +76,12 @@ variable "key_pair" {
   type        = string
 }
 
+variable "annotations" {
+  description = "Cluster annotation, key/value pair format"
+  type        = map(string)
+  default     = {}
+}
+
 variable "extend_param" {
   description = "Extended Parameters"
   type        = map(string)


### PR DESCRIPTION
Module version : 2.7.1
I would like to know if it's possible to add the parameter annotations of the resource flexibleengine_cce_cluster_v3, as an input of the module
Thanks in advance for this improvment